### PR TITLE
No-op on mobile / prohibitively small screens

### DIFF
--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -1,5 +1,9 @@
 
 var GraphRenderer = function(svgId, graph, svgWidth, svgHeight, folderInfoDiv, fileInfoDiv) {
+    // No-op on mobile / prohibitively small screens
+    if (window.innerWidth < 420) {
+        return;
+    }
 
     document.getElementById(svgId).setAttribute('height', svgHeight);
     document.getElementById(svgId).setAttribute("width", svgWidth);


### PR DESCRIPTION
Could consider not showing the graph while on mobile. Becase there are so many nodes, the d3 simulation takes a long time to settle with limited processing power (~40s on my pixel 5A). Additionally since there is no hover on mobile, user can't preview article title of the node, making it essentially a link to a random article.

After (fewer posts shown since I deleted a bunch to speed up build times while developing):
![127 0 0 1_8000_](https://user-images.githubusercontent.com/8715080/163920773-bf79f65c-3a75-478a-ad25-8f48884490f7.png)

